### PR TITLE
Updated _initialize_camp_database_mysql() to use the camp's my.cnf.

### DIFF
--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -2482,7 +2482,8 @@ EOF
 
 sub _initialize_camp_database_mysql {
     my $conf = shift;
-    my $cmd = "mysql_install_db --datadir=$conf->{db_data}";
+    _render_database_config($conf)  unless ($conf->{_did_render_database_config});
+    my $cmd = "mysql_install_db --datadir=$conf->{db_data} --defaults-file=$conf->{db_conf}";
     print "Preparing database instance:\n$cmd\n";
     system($cmd) == 0 or die "Error executing mysql_install_db!\n";
     return 1;


### PR DESCRIPTION
When running mysql_install_db pass in the generated my.cnf for the camp to make sure it uses the camp settings.
