### PR TITLE
Added camp_config() hash key '0number' which contains the camp number 0-...

### DIFF
--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -1411,10 +1411,11 @@ sub config_hash {
             unless defined $camp_number and $camp_number =~ /^\d+$/;
         $conf_hash = {
             %{ camp_user_info() },
-            number  => $camp_number,
-            name    => "camp$camp_number",
-            root    => camp_user_obj()->dir(),
-            type    => type(),
+            number      => $camp_number,
+            '0number'   => sprintf('%02d',$camp_number),
+            name        => "camp$camp_number",
+            root        => camp_user_obj()->dir(),
+            type        => type(),
             type_path   => type_path(),
             base_path   => base_path(),
         };


### PR DESCRIPTION
Added 0-padded camp number as camp_config() hash key '0number' so camp numbers less than 10 will have a leading 0 (like 07).  Then in config files in etc/ we can use tokens like: **CAMP_NUMBER**.camp.**CAMP_HOSTNAME**:67__CAMP_0NUMBER__

The port in the above example will now be 0-padded, port 6709 instead of 679.
