### PR TITLE
Let mkcamp use start instead of restart 

### DIFF
--- a/bin/mkcamp
+++ b/bin/mkcamp
@@ -140,7 +140,7 @@ END
 else {
     server_control(
         service => 'all',
-        action  => 'restart',
+        action  => 'start',
     );
     server_control(
         service => 'app',

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -989,11 +989,13 @@ When setting skip_apache, set this to the command to start your webserver. An ex
 
 When setting skip_apache, set this to the command to stop your webserver. An example with nginx:
 
- pid=`cat __CAMP_PATH__/var/run/nginx.pid 2>/dev/null` && kill $pid
+ /usr/sbin/nginx -c __CAMP_PATH__/nginx/nginx.conf -s stop
 
 =item httpd_restart
 
-pid=`cat __CAMP_PATH__/var/run/nginx.pid 2>/dev/null` && kill -HUP $pid || /usr/sbin/nginx -c __CAMP_PATH__/nginx/nginx.conf
+When setting skip_apache, set this to the command to restart your webserver. An example with nginx:
+
+ /usr/sbin/nginx -c __CAMP_PATH__/nginx/nginx.conf -s reload
 
 =item skip_ssl_cert_gen
 


### PR DESCRIPTION
This puzzled me - if you make a camp there won't be any server running. So IMHO it makes much more sense
to use "start" (first commit) which allows me to use more straightforward Nginx commandlines (no PID file
fiddling). The current variant is quite confusing.

Regards
               Racke