### PR TITLE
Fix broken regular expression for camp number in psql_camp script.

### DIFF
--- a/bin/psql_camp
+++ b/bin/psql_camp
@@ -8,7 +8,7 @@ use Camp::Master;
 
 my $camp;
 
-if (@ARGV and $ARGV[0] =~ /\A\d+\z/) {
+if (@ARGV and $ARGV[0] =~ /^\d+$/) {
     # first command-line argument can be camp number
     $camp = shift;
 }


### PR DESCRIPTION
Fixes longstanding mistake in psql_camp script. Also, if I compare it with mysql_camp, it looks like the poor
step child :-/
