### PR TITLE
Add proof of concept for generic mkcamp_command.

### DIFF
--- a/bin/mkcamp
+++ b/bin/mkcamp
@@ -122,6 +122,10 @@ process_copy_paths();
 # Substitute tokens in config files
 install_templates();
 
+# Run commands after installing templates
+# (e.g. to install Perl modules with carton)
+run_mkcamp_command('after_templates');
+
 # Prepare appserver(s)
 prepare_ic();
 prepare_rails();
@@ -158,7 +162,7 @@ however is appropriate.
 END
 }
 
-run_post_mkcamp_command();
+run_mkcamp_command('post');
 
 =pod
 

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -58,7 +58,7 @@ our $VERSION = '3.03';
     roles
     roles_path
     role_sql
-    run_post_mkcamp_command
+    run_mkcamp_command
     server_control
     set_camp_comment
     set_camp_user
@@ -3057,10 +3057,16 @@ sub camp_list {
     return @result;
 }
 
-sub run_post_mkcamp_command {
+sub run_mkcamp_command {
+    my $token = shift;
     my $conf = config_hash();
-    my $cmd = $conf->{post_mkcamp_command};
-    $cmd and return do_system_soft($cmd) == 0;
+    my $camp = $conf->{path};
+
+    if (my $cmd = $conf->{"${token}_mkcamp_command"}) {
+        chdir($camp) or die "Can not change directory to $camp: $!";
+        return do_system_soft($cmd) == 0;
+    }
+
     return;
 }
 


### PR DESCRIPTION
This by no means a complete implementation. Please tell me if you like this idea.
Our use case in `local-config`:

`after_templates_mkcamp_command:carton install`
