### PR TITLE
vcs_checkout: Update Git command for git_module

### DIFF
--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -1714,10 +1714,8 @@ sub vcs_checkout {
             }
 
             push @cmds, [
-                '(cd %s && git checkout --track -b %s %s/%s)',
+                '(cd %s && git checkout %s)',
                 $conf->{path},
-                $branch,
-                $repo,
                 $branch,
             ];
         }


### PR DESCRIPTION
Git no longer requires creating a local branch to check it out. This PR adjusts the command arguments allowing this process to work with modern Git.

Example error message with current usage.

```bash
(cd /home/patrick/camp66 && git checkout --track -b dev origin/dev)
fatal: A branch named 'dev' already exists.
Error! Exit code = 128
```