### PR TITLE
Master.pm: update MySQL init params for v5.7+

### DIFF
--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -2431,10 +2431,9 @@ EOF
 sub _initialize_camp_database_mysql {
     my $conf = shift;
     _render_database_config($conf) unless $conf->{_did_render_database_config};
-    my $opts = "--datadir=$conf->{db_data} --defaults-file=$conf->{db_conf}";
     my $cmd = (db_version_mysql() >= 5.7)
-        ? "mysqld $opts --initialize-insecure"
-        : "mysql_install_db $opts";
+        ? "mysqld --defaults-file=$conf->{db_conf} --initialize-insecure --datadir=$conf->{db_data}"
+        : "mysql_install_db --datadir=$conf->{db_data} --defaults-file=$conf->{db_conf}";
     print "Preparing database instance:\n$cmd\n";
     system($cmd) == 0 or die "Error executing mysql_install_db!\n";
     return 1;


### PR DESCRIPTION
The order of the init params passed to MySQL during mkcamp is important. Otherwise, mkcamp will fail because it does not use the  `--defaults-file` value.

ref: https://github.com/devcamps/camps/pull/33#discussion_r222317136