### PR TITLE
Fix post mkcamp command

### DIFF
--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -3027,10 +3027,13 @@ sub camp_list {
 
 sub run_post_mkcamp_command {
     my $conf = config_hash();
-    my $cmd = $conf->{post_mkcamp_command};
-    print $cmd, "\n";
-    $cmd and return do_system_soft($cmd) == 0;
-    return;
+    if (my $cmd = $conf->{post_mkcamp_command}) {
+        print $cmd, "\n";
+        return do_system_soft($cmd) == 0;
+    }
+    else {
+        return;
+    }
 }
 
 1;

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -3028,7 +3028,7 @@ sub camp_list {
 sub run_post_mkcamp_command {
     my $conf = config_hash();
     if (my $cmd = $conf->{post_mkcamp_command}) {
-        print $cmd, "\n";
+        print "Running post_mkcamp_command: $cmd\n";
         return do_system_soft($cmd) == 0;
     }
     else {


### PR DESCRIPTION
If not set, post-mkcamp-command was producing a useless warning.