### PR TITLE
New post-processing script facility

### DIFF
--- a/bin/mkcamp
+++ b/bin/mkcamp
@@ -81,10 +81,13 @@ initialize(
     user => $<,
 );
 
+my @post_ops = qw/files config mkcamp/;
+
 # Make sure we have enough disk space for our camp and database
 if (!$opt{skipdb}) {
     ## check_camp_size();
     ## check_db_size();
+    push @post_ops, 'db';
 }
 
 # Get camp # and verify everything's ok with camp database
@@ -108,6 +111,7 @@ if ($opt{skipvcs}) {
 }
 else {
     vcs_checkout($opt{replace});
+    push @post_ops, 'vcs';
 }
 
 # Must prepare database before installing templates; do so now.
@@ -128,6 +132,9 @@ prepare_rails();
 
 # Create Apache files
 prepare_apache();
+
+# Run post-processing for corresponding sections
+run_post_processing(@post_ops);
 
 # (Re)start facilities
 if ($opt{skipdb}) {
@@ -158,6 +165,7 @@ however is appropriate.
 END
 }
 
+# Deprecated. Use "mkcamp" context in post-processing.yml
 run_post_mkcamp_command();
 
 =pod

--- a/bin/refresh-camp
+++ b/bin/refresh-camp
@@ -46,21 +46,26 @@ if (!$showpod) {
         if $< != camp_user_obj()->uid()
     ;
 
+    my @post_ops = qw/refresh-camp/;
+
     if ($opt{vcs}) {
         vcs_refresh();
         $operation++;
+        push @post_ops, 'vcs';
     }
 
     if ($opt{db}) {
         # Run prepare_database with the force flag so it'll overwrite the existing one.
         prepare_database(1);
         $operation++;
+        push @post_ops, 'db';
     }
 
     if ($opt{config}) {
         # Run install_templates to rebuild templated config files and install them
         install_templates();
         $operation++;
+        push @post_ops, 'config';
     }
 
     if ($opt{files}) {
@@ -70,9 +75,13 @@ if (!$showpod) {
         process_copy_paths();
 
         $operation++;
+        push @post_ops, 'files';
     }
 
-    unless ($operation) {
+    if ($operation) {
+        run_post_processing(@post_ops);
+    }
+    else {
         $errmsg = 'Please specify the type(s) of refresh to perform.';
         $showpod++;
     }

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -526,9 +526,9 @@ sub run_post_processing {
             local $@;
             eval {
                 -e $cmd
-                    or die "File '$cmd' cannot be found";
+                    or die "File '$cmd' cannot be found\n";
                 -x $cmd
-                    or die "'$cmd' is not executable";
+                    or die "'$cmd' is not executable\n";
             };
 
             if (my $err = $@) {

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -526,13 +526,13 @@ sub run_post_processing {
             local $@;
             eval {
                 -e $cmd
-                    or die "File '$cmd' cannot be found\n";
+                    or die "File '$cmd' cannot be found.\n";
                 -x $cmd
-                    or die "'$cmd' is not executable\n";
+                    or die "'$cmd' is not executable.\n";
             };
 
             if (my $err = $@) {
-                chop ($err);
+                chomp ($err);
                 if ($script->{allow_errors}) {
                     warn "$err Skipping.\n";
                     next SCRIPT;


### PR DESCRIPTION
* Allows for an arbitrary number of post-processing scripts
  to run after a mkcamp or refresh-camp.

* Scripts are assigned to 1 or more contexts, indicating under
  what conditions they are to run:

  + global - run for every mkcamp and refresh-camp
  + mkcamp - run for every mkcamp
  + refresh-camp - run for every refresh-camp
  + files - run when the --files context is requested in refresh-camp
    or any run of mkcamp
  + config - run when the --config context is requested in refresh-camp
    or any run of mkcamp
  + db - run when --db context is request in refresh-camp or mkcamp
    when --skipdb is *not* set.
  + vcs - run when --vcs context is requested in refresh-camp or
    mkcamp when --skipvcs is *not* set.

* Code deprecates run_post_mkcamp_command() by setting up whatever
  script is configured to run there to run in the "mkcamp" context.