### PR TITLE
Add support for LVM thin pools

### DIFF
--- a/lib/Camp/LVM.pm
+++ b/lib/Camp/LVM.pm
@@ -112,14 +112,24 @@ sub create_lv {
 
     my @args = (
         '/usr/sbin/lvcreate',
-        "-L $lv_size",
         "-n $vg/$lv",
     );
+    if (!$conf->{lvm_thin_pool}) {
+        push @args, "-L $lv_size";
+    }
     if ($conf->{use_origin}) {
-        push @args, "-y -Wy -Zy";
+        if ($conf->{lvm_thin_pool}) {
+            push @args, "--thinpool $conf->{lvm_thin_pool} -V $lv_size -y -Wy";
+        }
+        else {
+            push @args, "-y -Wy -Zy";
+        }
     }
     else {
         push @args, "-s $vg/$conf->{lvm_origin_name}";
+        if ($conf->{lvm_thin_pool}) {
+            push @args, "--setactivationskip n --activate y";
+        }
     }
     my $cmd = join(' ', @args);
     print "Creating:\n$cmd\n";

--- a/lib/Camp/Master.pm
+++ b/lib/Camp/Master.pm
@@ -1509,6 +1509,10 @@ by this same size if their usage exceeds 50%.
 
 The LVM volume name to clone for snapshots.  For example, lvm_origin_volume:vg0/CampOriginDB.
 
+=item lvm_thin_pool
+
+The LVM thin pool to be used for the snapshots (optional). For example, lvm_thin_pool:vg0/thin_pool
+
 =item camp_subdirectories
 
 A space-separated list of directories that are expected to reside under your camp (naturally, these paths


### PR DESCRIPTION
SETUP

Create thin pool and configure to autoextend:

```
 # lvcreate --thin --size 100G --chunksize 256K --poolmetadatasize 1G vg0/thin_pool
 # lvmconfig --file /etc/lvm/profile/autoextend.profile --withcomments --config "activation/thin_pool_autoextend_threshold=60 activation/thin_pool_autoextend_percent=20"
 # lvchange --metadataprofile autoextend vg0/thin_pool
```

Add to local-config:

```
lvm_thin_pool:vg0/thin_pool
```